### PR TITLE
Add build helper using poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,21 @@ To create a standalone executable for Windows using PyInstaller:
    pip install .[pyinstaller]
    ```
 
-2. Build the executable from your package (replace `my_package` with your actual package name):
+2. Build the executable using Poetry:
+
+   ```
+   poetry run build-exe
+   ```
+
+   This runs PyInstaller with the required options and places the binary in the `dist` directory.
+
+3. (Optional) Invoke PyInstaller directly (replace `my_package` with your package name):
 
    ```
    pyinstaller --onefile -m my_package
    ```
 
-   The generated executable will be located in the `dist` directory.
+   The generated executable will also be located in the `dist` directory.
 
 For more advanced options, refer to the [PyInstaller documentation](https://pyinstaller.org/).
 

--- a/mydesktop/build.py
+++ b/mydesktop/build.py
@@ -1,0 +1,12 @@
+import sys
+from PyInstaller.__main__ import run
+
+
+def main() -> None:
+    """Build a standalone executable using PyInstaller."""
+    args = ["--onefile", "-m", "mydesktop"] + sys.argv[1:]
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ requires-python = ">=3.8"
 dev-requirements = {file = "dev-requirements.txt"}
 pyinstaller = ["pyinstaller"]
 
+[project.scripts]
+build-exe = "mydesktop.build:main"
+
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/tests/test_date_time.py
+++ b/tests/test_date_time.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from my_package.__main__ import date
+from mydesktop.__main__ import date
 
 
 @pytest.fixture

--- a/tests/test_developer.py
+++ b/tests/test_developer.py
@@ -1,5 +1,5 @@
 import pytest
-from my_package.__main__ import Developer
+from mydesktop.__main__ import Developer
 
 
 def test_get_info():


### PR DESCRIPTION
## Summary
- fix tests to import from package `mydesktop`
- add helper script `mydesktop.build` for creating a PyInstaller executable
- expose the helper via `build-exe` script in `pyproject.toml`
- document how to run the build using `poetry run`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f4afc5e0832b928230580454d4d8