### PR TITLE
Implement basic Texture TUI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 setuptools
 wheel
+textual

--- a/mydesktop/__main__.py
+++ b/mydesktop/__main__.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
 
 class Developer:
     valid_languages: list[str] = [
@@ -46,11 +49,16 @@ def date() -> datetime:
     return current_datetime
 
 
+class TextureApp(App):
+    """Minimal TUI application with a default screen."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("Hello from Texture!")
+
+
 def main() -> None:
-    start_coding()
-    print(date())
-    dev = Developer("Alice", "Python")
-    print(dev.get_info())
+    TextureApp().run()
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/tests/test_texture_app.py
+++ b/tests/test_texture_app.py
@@ -1,0 +1,17 @@
+import pytest
+from mydesktop.__main__ import TextureApp
+from textual.app import App
+from textual.widgets import Static
+
+
+def test_app_is_subclass_of_app():
+    assert issubclass(TextureApp, App)
+
+
+def test_compose_returns_static_widget():
+    app = TextureApp()
+    widgets = list(app.compose())
+    assert len(widgets) == 1
+    widget = widgets[0]
+    assert isinstance(widget, Static)
+    assert widget.renderable == "Hello from Texture!"


### PR DESCRIPTION
## Summary
- add `TextureApp` for a minimal Textual TUI
- include `textual` in dev requirements
- test the new TUI

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f8ef2830832ba3af1ffada9d31df