### PR TITLE
Add exit options for TextureApp

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 setuptools
 wheel
+textual

--- a/mydesktop/__main__.py
+++ b/mydesktop/__main__.py
@@ -1,5 +1,8 @@
 from datetime import datetime
 
+from textual.app import App, ComposeResult
+from textual.widgets import Static, Button, Footer
+
 
 class Developer:
     valid_languages: list[str] = [
@@ -46,11 +49,30 @@ def date() -> datetime:
     return current_datetime
 
 
+class TextureApp(App):
+    """Minimal TUI application with a default screen."""
+
+    BINDINGS = [
+        ("ctrl+q", "quit", "Quit"),
+        ("ctrl+shift+q", "quit", "Quit"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Press CTRL+Q or CTRL+SHIFT+Q or use the Quit button to exit.",
+            id="message",
+        )
+        yield Button("Quit", id="quit-button")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "quit-button":
+            self.exit()
+
+
 def main() -> None:
-    start_coding()
-    print(date())
-    dev = Developer("Alice", "Python")
-    print(dev.get_info())
+    TextureApp().run()
 
 
-main()
+if __name__ == "__main__":
+    main()

--- a/tests/test_texture_app.py
+++ b/tests/test_texture_app.py
@@ -1,0 +1,32 @@
+import pytest
+from mydesktop.__main__ import TextureApp
+from textual.app import App
+from textual.widgets import Static, Button, Footer
+from unittest.mock import MagicMock
+
+
+def test_app_is_subclass_of_app():
+    assert issubclass(TextureApp, App)
+
+
+def test_bindings_contain_quit_shortcuts():
+    assert ("ctrl+q", "quit", "Quit") in TextureApp.BINDINGS
+    assert ("ctrl+shift+q", "quit", "Quit") in TextureApp.BINDINGS
+
+
+def test_compose_contains_widgets():
+    app = TextureApp()
+    widgets = list(app.compose())
+    assert any(isinstance(w, Static) for w in widgets)
+    assert any(isinstance(w, Button) for w in widgets)
+    assert any(isinstance(w, Footer) for w in widgets)
+
+
+def test_button_triggers_exit():
+    app = TextureApp()
+    mock_exit = MagicMock()
+    app.exit = mock_exit
+    button = Button("Quit", id="quit-button")
+    event = Button.Pressed(button)
+    app.on_button_pressed(event)
+    mock_exit.assert_called_once()


### PR DESCRIPTION
## Summary
- handle `ctrl+q` and `ctrl+shift+q` shortcuts
- add quit button and footer to the TUI
- update tests for new UI and bindings

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840f8ef2830832ba3af1ffada9d31df